### PR TITLE
Location data from resource

### DIFF
--- a/ckanext/string_to_location/controller.py
+++ b/ckanext/string_to_location/controller.py
@@ -50,14 +50,20 @@ class LocationMapperController(PackageController):
         target_entity_type = OnsEntityTypes.LOCAL_AUTHORITY_DISTRICT
         
         resource_path = uploader.get_resource_uploader(resource).get_path(resource['id'])
-        column_name = 'Local authority'
-        is_name = True
+
+        if 'location_column' in resource and 'location_type' in resource:
+            column_name = resource['location_column']
+            is_name = resource['location_type'].endswith('_name')
+        elif 'location_column' in resource['extras'] and 'location_type' in resource['extras']:
+            column_name = resource['location_column']
+            is_name = resource['location_type'].endswith('_name')
+        else:
+            raise MissingValue
 
         resource_contents = codecs.open(resource_path, 'rb', 'cp1257')
 
         table = pandas.read_csv(resource_contents)
 
-        resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
         log_writer.info("Read file in")
 
         def get_geometry(name):

--- a/ckanext/string_to_location/controller.py
+++ b/ckanext/string_to_location/controller.py
@@ -34,6 +34,7 @@ import csv
 import geojson
 from geojson import Feature, FeatureCollection
 import pandas
+import ast
 
 
 class LocationMapperController(PackageController):
@@ -54,11 +55,14 @@ class LocationMapperController(PackageController):
         if 'location_column' in resource and 'location_type' in resource:
             column_name = resource['location_column']
             is_name = resource['location_type'].endswith('_name')
-        elif 'location_column' in resource['extras'] and 'location_type' in resource['extras']:
-            column_name = resource['location_column']
-            is_name = resource['location_type'].endswith('_name')
+        elif 'location_column' in resource['_extras'] and 'location_type' in resource['_extras']:
+            extras = ast.literal_eval(resource['_extras'])
+            column_name = extras['location_column']
+            is_name = extras['location_type'].endswith('_name')
         else:
-            raise MissingValue
+            log_writer.error("The resource does not specify location columns", state="Something went wrong")
+            return helpers.redirect_to(controller='ckanext.string_to_location.controller:LocationMapperController',
+                                   action='resource_location_mapping_status', id=id, resource_id=resource_id)
 
         resource_contents = codecs.open(resource_path, 'rb', 'cp1257')
 


### PR DESCRIPTION
1. Check if the location column and type are specified on the resource. If yes, proceed.
2. Check if the location column and type have been passed in as extras. This is in mainly so we can test the functionality without needed to update the schema or needing to rely on other plugins.
3. If neither of the above are true, log an error and redirect to the Location Mapper status tab.