### PR TITLE
Swap NaN for null in geojson output

### DIFF
--- a/ckanext/string_to_location/controller.py
+++ b/ckanext/string_to_location/controller.py
@@ -124,7 +124,7 @@ class LocationMapperController(PackageController):
         geojson_version = matches_to_geojson(matches, list(table.columns))
 
         output_buffer = StringIO()
-        geojson.dump(geojson_version, output_buffer, allow_nan=True)
+        geojson.dump(geojson_version, output_buffer, ignore_nan=True)
 
         #
         # Summary info


### PR DESCRIPTION
The previewer doesn't accept `NaN` values, so we just swap them out for `null`